### PR TITLE
opens postgresql port to the host operating system.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ RUN echo "deb http://downloads.sourceforge.net/project/sonar-pkg/deb binary/" >>
 RUN apt-get update && apt-get clean ### Sonar version 5.0 - timestamp
 
 RUN apt-get install -y --force-yes sonar=5.0
-
+RUN curl http://repository.codehaus.org/org/codehaus/sonar-plugins/php/sonar-php-plugin/2.4/sonar-php-plugin-2.4.jar > /opt/sonar/extensions/plugins/sonar-php-plugin-2.4.jar
 COPY assets/init /app/init
 RUN chmod 755 /app/init
-
+RUN chmod 755 /opt/sonar/extensions/plugins/sonar-php-plugin-2.4.jar
 VOLUME /opt/sonar/extensions
 VOLUME /opt/sonar/logs/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ RUN echo "deb http://downloads.sourceforge.net/project/sonar-pkg/deb binary/" >>
 RUN apt-get update && apt-get clean ### Sonar version 5.0 - timestamp
 
 RUN apt-get install -y --force-yes sonar=5.0
-RUN curl http://repository.codehaus.org/org/codehaus/sonar-plugins/php/sonar-php-plugin/2.4/sonar-php-plugin-2.4.jar > /opt/sonar/extensions/plugins/sonar-php-plugin-2.4.jar
+
 COPY assets/init /app/init
 RUN chmod 755 /app/init
-RUN chmod 755 /opt/sonar/extensions/plugins/sonar-php-plugin-2.4.jar
+
 VOLUME /opt/sonar/extensions
 VOLUME /opt/sonar/logs/
 

--- a/fig.yml
+++ b/fig.yml
@@ -6,6 +6,8 @@ postgresql:
     - POSTGRESQL_DB=sonar
   volumes:
     - /opt/db/sonarqube/:/var/lib/postgresql
+  ports: 
+    - "5432:5432"
 sonarqube:
   image: harbur/sonarqube:latest
   links:
@@ -15,5 +17,5 @@ sonarqube:
     - DB_PASS=xaexohquaetiesoo
     - DB_NAME=sonar
   ports:
-    - "9000"
+    - "9000:9000"
     - "443"


### PR DESCRIPTION
`sonar-runner` and other sonar clients will store their reports directly
in the database. This will only work if the database is publically reachable.

defined fixed port forwardings for postgres and sonar. Anything else
will be very inconvenient for using with sonar, as the ports need to
be hardcoded in the configuration of the sonar client.