### PR TITLE
Use link name in jdbc url instead of IP address

### DIFF
--- a/assets/init
+++ b/assets/init
@@ -4,7 +4,7 @@ set -e
 trap appStop SIGINT SIGTERM
 
 # Variables
-DB_HOST=$DB_PORT_5432_TCP_ADDR
+DB_HOST=${DB_HOST:-db}
 DB_NAME=${DB_NAME:-sonar}
 DB_USER=${DB_USER:-sonar}
 DB_PASS=${DB_PASS:-xaexohquaetiesoo}


### PR DESCRIPTION
On an OSX host, using docker-machine (0.4.1), docker-compose (1.4.0) and docker (1.8.1, build d12ea79), for some reason occasionally the IP address for `db` (`$DB_PORT_5432_TCP_ADDR` or `grep '\<db\>' /etc/hosts`) changes after the `init` script has configured the jdbc url in `sonar.properties`, which obviously causes problems for SonarQube:

    sonarqube_1  | 2015.08.18 18:31:15 INFO  web[o.s.c.p.Database] Create JDBC datasource for jdbc:postgresql://172.17.0.57/sonar
    sonarqube_1  | 2015.08.18 18:31:18 ERROR web[o.a.c.c.C.[.[.[/]] Exception sending context initialized event to listener instance of class org.sonar.server.platform.PlatformServletContextListener
    sonarqube_1  | java.lang.IllegalStateException: Can not connect to database. Please check connectivity and settings (see the properties prefixed by 'sonar.jdbc.').

There seems to be a race condition somewhere, I haven't found what causes this (something in docker itself?). It only appears to happen when restarting everything with docker-compose.

In any case, if we replace the explicit IP address in `sonar.properties` with a lookup by host name, this issue no longer happens on my machine; by the time the db container's IP address has been updated, docker has also updated `/etc/hosts`.