### PR TITLE
Fix issue with apt-transport-https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM java:openjdk-8-jre
 MAINTAINER spiddy <d.kapanidis@gmail.com>
 
+RUN apt-get update && apt-get install -qy apt-transport-https
 RUN echo "deb http://downloads.sourceforge.net/project/sonar-pkg/deb binary/" >> /etc/apt/sources.list
 RUN apt-get update && apt-get clean ### Sonar version 5.6 - timestamp
 


### PR DESCRIPTION
Fix for #17 

See also:
[1] https://www.digitalocean.com/community/questions/how-to-fix-e-the-method-driver-usr-lib-apt
[2] http://idavit.blogspot.ch/2016/12/error-while-dockerizing-sonarqube-using.html